### PR TITLE
feat: add GoImpl + automatically install go binaries for vim-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install: cleanup bootstrap
 	cp init.lua $(NEOVIM_HOME)
 	cp -r lua $(NEOVIM_HOME)
 	nvim --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'
+	nvim --headless +GoInstallBinaries +q
 	cp -r after $(NEOVIM_HOME)
 	cp -r ftplugin $(NEOVIM_HOME)
 	go install golang.org/x/tools/cmd/goimports@v0.18.0

--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -1,3 +1,4 @@
 vim.keymap.set("n", "<leader>t", ":GoTest<CR>")
 vim.keymap.set("n", "<leader>a", ":GoAlternate<CR>")
+vim.keymap.set("n", "<leader>i", ":GoImpl<CR>")
 vim.g.go_fmt_command = "goimports"


### PR DESCRIPTION
Details: https://github.com/fatih/vim-go/blob/5332cd8f60340bf09f46ba1765b8661cd16041e4/doc/vim-go.txt#L776
Quite useful when writing a quick test stub for some interface by hand, of when implementing an interface in general :-)